### PR TITLE
test: replace testing library with Callstack's implementation

### DIFF
--- a/ResponsiveImageView.test.js
+++ b/ResponsiveImageView.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import { render as ntlRender } from '@testing-library/react-native';
+import { render } from 'react-native-testing-library';
 import {
   mockUriGood,
   mockUriBad,
@@ -22,19 +22,19 @@ describe('rendering order (component > render > FAC > children > null)', () => {
   describe('renders component if provided', () => {
     it('function', () => {
       const MyRenderComponent = jest.fn(() => null);
-      const render = jest.fn(() => null);
+      const renderProp = jest.fn(() => null);
       const children = jest.fn(() => null);
-      ntlRender(
+      render(
         <ResponsiveImageView
           source={{ uri: mockUriGood }}
           component={MyRenderComponent}
-          render={render}
+          render={renderProp}
         >
           {children}
         </ResponsiveImageView>,
       );
       expect(MyRenderComponent).toHaveBeenCalledWith(expectedShape);
-      expect(render).not.toHaveBeenCalled();
+      expect(renderProp).not.toHaveBeenCalled();
       expect(children).not.toHaveBeenCalled();
     });
 
@@ -46,38 +46,38 @@ describe('rendering order (component > render > FAC > children > null)', () => {
         }
       }
 
-      const render = jest.fn(() => null);
+      const renderProp = jest.fn(() => null);
       const children = jest.fn(() => null);
-      ntlRender(
+      render(
         <ResponsiveImageView
           source={{ uri: mockUriGood }}
           component={MyRenderClassComponent}
-          render={render}
+          render={renderProp}
         >
           {children}
         </ResponsiveImageView>,
       );
       expect(classRenderMethod).toHaveBeenCalledWith(expectedShape);
-      expect(render).not.toHaveBeenCalled();
+      expect(renderProp).not.toHaveBeenCalled();
       expect(children).not.toHaveBeenCalled();
     });
   });
 
   it('calls render if no component was provided', () => {
-    const render = jest.fn(() => null);
+    const renderProp = jest.fn(() => null);
     const children = jest.fn(() => null);
-    ntlRender(
-      <ResponsiveImageView source={{ uri: mockUriGood }} render={render}>
+    render(
+      <ResponsiveImageView source={{ uri: mockUriGood }} render={renderProp}>
         {children}
       </ResponsiveImageView>,
     );
-    expect(render).toHaveBeenCalledWith(expectedShape);
+    expect(renderProp).toHaveBeenCalledWith(expectedShape);
     expect(children).not.toHaveBeenCalled();
   });
 
   it('calls children function if no component or render prop was provided', () => {
     const children = jest.fn(() => null);
-    ntlRender(
+    render(
       <ResponsiveImageView source={{ uri: mockUriGood }}>
         {children}
       </ResponsiveImageView>,
@@ -86,7 +86,7 @@ describe('rendering order (component > render > FAC > children > null)', () => {
   });
 
   it('renders children if no component, render prop, or FAC was provided', () => {
-    const { getByText } = ntlRender(
+    const { getByText } = render(
       <ResponsiveImageView source={{ uri: mockUriGood }}>
         <View>
           <Text>Hello from non-functional children!</Text>
@@ -97,7 +97,7 @@ describe('rendering order (component > render > FAC > children > null)', () => {
   });
 
   it('renders null if no renderer was provided', () => {
-    const { queryByText } = ntlRender(
+    const { queryByText } = render(
       <ResponsiveImageView source={{ uri: mockUriGood }} />,
     );
     expect(queryByText(/.*/)).toBeNull();
@@ -107,19 +107,19 @@ describe('rendering order (component > render > FAC > children > null)', () => {
 describe('completion callbacks', () => {
   it("doesn't throw on success if no onLoad was provided", () => {
     expect(() =>
-      ntlRender(<ResponsiveImageView source={{ uri: mockUriGood }} />),
+      render(<ResponsiveImageView source={{ uri: mockUriGood }} />),
     ).not.toThrow();
   });
 
   it("doesn't throw on failure if no onError was provided", () => {
     expect(() =>
-      ntlRender(<ResponsiveImageView source={{ uri: mockUriBad }} />),
+      render(<ResponsiveImageView source={{ uri: mockUriBad }} />),
     ).not.toThrow();
   });
 
   it('calls provided onLoad on URI success', () =>
     new Promise((resolve, reject) => {
-      ntlRender(
+      render(
         <ResponsiveImageView
           source={{ uri: mockUriGood }}
           onLoad={resolve}
@@ -130,7 +130,7 @@ describe('completion callbacks', () => {
 
   it('calls provided onError on URI failure', () =>
     new Promise((resolve, reject) => {
-      ntlRender(
+      render(
         <ResponsiveImageView
           source={{ uri: mockUriBad }}
           onLoad={reject}
@@ -141,7 +141,7 @@ describe('completion callbacks', () => {
 
   it('calls provided onLoad on imported resource success', () =>
     new Promise((resolve, reject) => {
-      ntlRender(
+      render(
         <ResponsiveImageView
           source={mockResourceGood}
           onLoad={resolve}
@@ -152,7 +152,7 @@ describe('completion callbacks', () => {
 
   it('calls provided onError on imported resource failure', () =>
     new Promise((resolve, reject) => {
-      ntlRender(
+      render(
         <ResponsiveImageView
           source={mockResourceBad}
           onLoad={reject}
@@ -163,7 +163,7 @@ describe('completion callbacks', () => {
 
   it('does not call onLoad on success after unmounting', () =>
     new Promise((resolve, reject) => {
-      const { unmount } = ntlRender(
+      const { unmount } = render(
         <ResponsiveImageView
           source={{ uri: mockUriSlowGood }}
           onLoad={reject}
@@ -176,7 +176,7 @@ describe('completion callbacks', () => {
 
   it('does not call onError on failure after unmounting', () =>
     new Promise((resolve, reject) => {
-      const { unmount } = ntlRender(
+      const { unmount } = render(
         <ResponsiveImageView
           source={{ uri: mockUriSlowBad }}
           onLoad={reject}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test'],
   coverageReporters: ['html', 'json', 'lcov', 'text'],
-  preset: '@testing-library/react-native',
+  preset: 'react-native',
   setupFilesAfterEnv: ['<rootDir>/test/setupTests.js'],
   watchPlugins: [
     'jest-watch-typeahead/filename',

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@babel/core": "7.10.5",
     "@commitlint/cli": "9.1.1",
     "@commitlint/config-conventional": "9.1.1",
-    "@testing-library/react-native": "5.0.3",
     "@wkovacs64/prettier-config": "3.0.0",
     "babel-jest": "26.1.0",
     "codecov": "3.7.0",
@@ -76,6 +75,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "0.62.2",
+    "react-native-testing-library": "2.1.1",
     "react-test-renderer": "16.13.1",
     "rimraf": "3.0.2",
     "semantic-release": "17.1.1"

--- a/useResponsiveImageView.test.js
+++ b/useResponsiveImageView.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render } from 'react-native-testing-library';
 import {
   mockUriGood,
   mockUriBad,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,15 +1709,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^25.2.6":
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.2.6.tgz#c12f44af9bed444438091e4b59e7ed05f8659cb6"
@@ -2009,14 +2000,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@testing-library/react-native@5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-5.0.3.tgz#8821dcf7fe7364bc7f427d853cd96e4407d88a4f"
-  integrity sha512-lQH7vUgwESfagFw4BlKsfpX7Rv/m7h2NYfubY0aoQromSwI1slCxrhwZws8gABTXweob/DyLATsOamHsWdwDnA==
-  dependencies:
-    pretty-format "^24.9.0"
-    wait-for-expect "^3.0.0"
-
 "@textlint/ast-node-types@^4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-4.0.3.tgz#b51c87bb86022323f764fbdc976b173f19261cc5"
@@ -2199,13 +2182,6 @@
   version "12.0.9"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.9.tgz#693e76a52f61a2f1e7fb48c0eef167b95ea4ffd0"
   integrity sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==
-
-"@types/yargs@^13.0.0":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.2.tgz#a64674fc0149574ecd90ba746e932b5a5f7b3653"
-  integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.1"
@@ -4167,7 +4143,7 @@ debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -6080,7 +6056,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7698,11 +7674,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7711,32 +7682,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -7782,11 +7731,6 @@ lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -8912,7 +8856,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -8927,7 +8870,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -8946,14 +8888,8 @@ npm@^6.10.3:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -9711,16 +9647,6 @@ pretty-format@^24.7.0, pretty-format@^24.8.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
 pretty-format@^25.2.0:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.2.6.tgz#542a1c418d019bbf1cca2e3620443bc1323cb8d7"
@@ -9731,7 +9657,7 @@ pretty-format@^25.2.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-format@^26.1.0:
+pretty-format@^26.0.1, pretty-format@^26.1.0:
   version "26.1.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.1.0.tgz#272b9cd1f1a924ab5d443dc224899d7a65cb96ec"
   integrity sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==
@@ -9951,6 +9877,13 @@ react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-native-testing-library@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-testing-library/-/react-native-testing-library-2.1.1.tgz#f40b17aff707731a29bd596cab49fb3f4768ac2e"
+  integrity sha512-iorikwlADclvzvHWEE+zB8FdJctP8BtzdWj6C6ECU17B4iSCJ228iF2xcoE47/BKAeHMNRk5WbL0zsWpUvnPgA==
+  dependencies:
+    pretty-format "^26.0.1"
 
 react-native@0.62.2:
   version "0.62.2"
@@ -12216,11 +12149,6 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.0.tgz#d6fbf28959e3b8779dc172fb1ea56bf1e833bf7a"
-  integrity sha512-9LyJL+MugZdcQn5V9PBSEC4d2UPTy1xX2U9wTc6LvG/18qeeYqdE/CgmAQJxc/Vcjs+VzH+wiyIXxz05F3nrpQ==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
`@testing-library/react-native` is being deprecated in favor of `react-native-testing-library`.