### PR TITLE
chore: document retry effect dependency

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -224,6 +224,7 @@ export function useResponsiveImageView({
     return () => {
       pendingGetImageSize.cancel();
     };
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- Retry count intentionally retriggers image loading.
   }, [imageIdOrUri, state.retryCount]);
 
   return {


### PR DESCRIPTION
Document and suppress the intentional extra effect dependency. `state.retryCount` retriggers image loading when `retry()` is called.

This prepares the branch for the stricter React Compiler rules in `@wkovacs64/oxlint-config` 0.2.